### PR TITLE
Fixed wrong type being returned

### DIFF
--- a/noitaglobalstore.lua
+++ b/noitaglobalstore.lua
@@ -13,7 +13,12 @@ stringstore.noita.global = function(base_name)
 		end,
 
 		get_type = function(key, val)
-			return GlobalsGetValue(base_name .. "." .. key .. ".type")
+			local stored_type = GlobalsGetValue(base_name .. "." .. key .. ".type")
+			if stored_type == "" then
+				return nil
+			else
+				return stored_type
+			end
 		end,
 
 		get = function(key)


### PR DESCRIPTION
Hey there, checked out your little utility lib here and noticed it failed at checking if a field is initialized using:
```lua
if TEST_STORE.some_numeric_field == nil then -- Crashes here
  TEST_STORE.some_numeric_field = 123
end
```
So I did some debugging and hopefully fixed it.
The Problem is that GlobalsGetValue returns an empty string instead of nil when the value does not exist.
I don't know if this is a good solution but it works for me. Thought I could use this opportunity to try my first pull request :)