### PR TITLE
Fix error when EntityGetComponent returns nil

### DIFF
--- a/noitavariablestore.lua
+++ b/noitavariablestore.lua
@@ -24,10 +24,12 @@ function stringstore.noita.variable_storage_components(entity_id)
 
 	local storage_cache = {}
 
-	for i, v in ipairs(components) do
-		local name = ComponentGetValue(v, "name")
+	if components ~= nil then
+		for i, v in ipairs(components) do
+			local name = ComponentGetValue(v, "name")
 
-		storage_cache[name] = v
+			storage_cache[name] = v
+		end
 	end
 
 	return {

--- a/test.lua
+++ b/test.lua
@@ -70,7 +70,11 @@ function EntityGetComponent(entity_id, comp_name)
 			table.insert(comp_ids, v)
 		end
 	end
-	return comp_ids
+	if #comp_ids == 0 then
+		return nil
+	else
+		return comp_ids
+	end
 end
 
 print("")


### PR DESCRIPTION
When EntityGetComponent doesn't find a Component it does not return an empty table, but nil. Added a nil check before using ipairs on nil. Updated the test stub function of EntityGetComponent to mimic that behaviour.

I already had this fix in place for my own mod but never realized it until now.
So here's me finally sharing the fix :)